### PR TITLE
Updating deprecated methods "characters"

### DIFF
--- a/Pod/Classes/CLTypingLabel.swift
+++ b/Pod/Classes/CLTypingLabel.swift
@@ -141,7 +141,7 @@ import UIKit
     
     private func setTextWithTypingAnimation(_ typedText: String, _ attributes: Dictionary<NSAttributedStringKey, Any>?, _ charInterval: TimeInterval, _ initial: Bool, _ dispatchID: Int) {
         
-        guard typedText.characters.count > 0 && currentDispatchID == dispatchID else {
+        guard !typedText.isEmpty && currentDispatchID == dispatchID else {
             typingOver = true
             typingStopped = false
             if let nonNilBlock = onTypingAnimationFinished {
@@ -159,7 +159,7 @@ import UIKit
             super.text = ""
         }
         
-        let firstCharIndex = typedText.characters.index(typedText.startIndex, offsetBy: 1)
+        let firstCharIndex = typedText.index(typedText.startIndex, offsetBy: 1)
         
         DispatchQueue.main.async {
             if let attributes = attributes {


### PR DESCRIPTION
Update CLTypingLabel.swift:
The method 'characters' is deprecated, so changing these methods to use String method instead.